### PR TITLE
Fix where extraction to work for ISO dates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,8 @@ const extractWhere = ({ query, basedProperties, symbolic }) => {
   let whereClause = {};
   for (let property in properties) {
     if (properties[property].includes(':')) {
-      let [comparisonOp, value] = properties[property].split(':');
+      let index = properties[property].indexOf(':');
+      let [comparisonOp, value] = [properties[property].slice(0, index), properties[property].slice(index + 1)];
       if (comparisonOp in operators) {
         let result = operators[comparisonOp](symbolic, value);
         whereClause[property] = { [result.comparisonOp]: result.value === 'null' ? null : result.value };

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,15 +6,22 @@ const extractSort = ({ sort, basedProperties }) => {
 
   let sortClause = [];
   let properties = sort.split(',');
-
   if (basedProperties.length > 0) {
-    properties =  properties.filter(property => basedProperties.includes(property.replace(/^-/, '')));
+    properties = properties.filter(property => basedProperties.includes(property.replace(/^-?\+?/, '')));
   }
 
   if (properties.length) {
-    properties = properties.length > 1 ? uniqBy(properties, item => item.replace(/^-/, '')) : properties;
+
+    properties = properties.length > 1 ? uniqBy(properties, item => item.replace(/^-?\+/, '')) : properties;
     sortClause = properties.map(property => {
-      return property.charAt(0) === '-' ? [property.slice(1), 'DESC'] : [property, 'ASC']
+        switch(property.charAt(0)) {
+            case '-':
+            return [property.slice(1), 'DESC']
+            case '+':
+            return [property.slice(1), 'ASC']
+            default:
+            return [property, 'ASC']
+        }
     });
   }
 


### PR DESCRIPTION
Currently a between statement with 2 iso dates  http://www.example.com/players?createdAt=between:2020-05-03T15:48:18.000Z,2020-05-05T09:19:56.000Z

was producing the following
```
query: [ 'between', '2020-05-03T15' ]
sql: WHERE createdAt BETWEEN '2020-05-03 12:00:00' AND NULL
```

It now produces the following:
```
query: [ 'between', '2020-05-04T15:48:18.000Z,2020-05-05T09:19:56.000Z' ]
sql: WHERE createdAt BETWEEN '2020-05-03 15:48:18' AND '2020-05-05 09:19:56'
```